### PR TITLE
add as_raw_value helper to SecretKeyShare

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 name = "blsful"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/blsful"
-version = "2.5.0"
+version = "2.5.1"
 
 [features]
 default = ["blst"]

--- a/src/secret_key_share.rs
+++ b/src/secret_key_share.rs
@@ -63,4 +63,9 @@ impl<C: BlsSignatureImpl> SecretKeyShare<C> {
             )),
         }
     }
+
+    /// Extract the inner raw representation
+    pub fn as_raw_value(&self) -> &<C as Pairing>::SecretKeyShare {
+        &self.0
+    }
 }


### PR DESCRIPTION
Add a `as_raw_value()` helper function to SecretKeyShare to help with getting the inner value properly typed without a bunch of angle brackets.