### PR TITLE
fix InnerPointG*Impl to call correct vsss_rs::Share::value_vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl Share for InnerPointShareG1 {
     }
 
     fn value_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
+        self.0.value_vec()
     }
 }
 
@@ -271,6 +271,6 @@ impl Share for InnerPointShareG2 {
     }
 
     fn value_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
+        self.0.value_vec()
     }
 }


### PR DESCRIPTION
The `InnerPointG1Impl::value_vec` and `InnerPointG2Impl::value_vec` functions were not calling the `vsss_rs::Share::value_vec` functions to get the actual value. Instead they were returning the full slice containing the identifier u8 and the value. This patch fixes that. 